### PR TITLE
Sign up team

### DIFF
--- a/app/models/sign_up_team.rb
+++ b/app/models/sign_up_team.rb
@@ -1,0 +1,22 @@
+class SignUpTeam < ApplicationRecord
+  belongs_to :sign_up_topic counter_cache:true
+  
+  validates :is_waitlisted, presence: true 
+
+  def create_sign_up_team(is_waitlisted,topic_id)
+    sign_up_team = SignUpTeam.new
+    sign_up_team.is_waitlisted=is_waitlisted
+    sign_up_team.topic_id=topic_id 
+    sign_up_team.save 
+  end 
+
+  def delete_sign_up_team(id)
+    sign_up_team = SignUpTeam.where(id: id)
+    sign_up_team.destroy
+    end 
+
+  def update_sign_up_team(id)
+    #TODO: This can be done after Team model is built.
+  end
+
+end

--- a/db/migrate/20230320202607_create_sign_up_teams.rb
+++ b/db/migrate/20230320202607_create_sign_up_teams.rb
@@ -1,0 +1,10 @@
+class CreateSignUpTeams < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sign_up_teams do |t|
+      t.references :sign_up_topic, null: false, foreign_key: true
+      t.boolean :is_waitlisted
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_20_135246) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_202607) do
   create_table "assignments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "directory_path"
@@ -74,6 +74,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_135246) do
     t.index ["parent_id"], name: "fk_rails_4404228d2f"
   end
 
+  create_table "sign_up_teams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "sign_up_topic_id", null: false
+    t.boolean "is_waitlisted"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sign_up_topic_id"], name: "index_sign_up_teams_on_sign_up_topic_id"
+  end
+
   create_table "sign_up_topics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.integer "max_choosers"
@@ -109,4 +117,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_135246) do
   end
 
   add_foreign_key "roles", "roles", column: "parent_id", on_delete: :cascade
+  add_foreign_key "sign_up_teams", "sign_up_topics"
 end

--- a/test/fixtures/sign_up_teams.yml
+++ b/test/fixtures/sign_up_teams.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  sign_up_topic: one
+  is_waitlisted: false
+
+two:
+  sign_up_topic: two
+  is_waitlisted: false

--- a/test/models/sign_up_team_test.rb
+++ b/test/models/sign_up_team_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SignUpTeamTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Summary: This change adds the sign_up_team model and the corresponding methods as described in the design document.

Methods added:

create_sign_up_team - Create a sign_up_team using given parameters
update_sign_up_team - Update a sign_up_team using given parameters
delete_sign_up_team - Delete a sign_up_team using given parameters