### PR TITLE
Add tests for all helper functions

### DIFF
--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -32,6 +32,7 @@ class SignUpTopic < ApplicationRecord
     sign_up_topic.category = category
     sign_up_topic.description = description
     sign_up_topic.save
+    return sign_up_topic
   end
 
   # Delete topic based on primary key i.e., name of topic.

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -21,6 +21,7 @@ class SignUpTopic < ApplicationRecord
     sign_up_topic.topic_identifier = topic_identifier
     sign_up_topic.description = description
     sign_up_topic.save
+    return sign_up_topic
   end
 
   # Update max choosers | category | description based on name i.e., primary key.

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -45,8 +45,7 @@ class SignUpTopic < ApplicationRecord
   # Format the given active record for display.
   def format_for_display()
     contents_for_display = ''
-    contents_for_display += topic_identifier.to_s + ' - '
-    topic_display + topic_name
+    contents_for_display += topic_identifier.to_s + ' - ' + name.to_s
   end
 
   # Send update to all waitlisted users regarding waitlist changes.

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -13,18 +13,26 @@ RSpec.describe SignUpTopic, type: :model do
     expect(SignUpTopic.new(name: "temp", max_choosers: 10)).to be_valid
   end
 
-  describe "test helper methods" do
-    it "create record via helper method" do
-      temp = SignUpTopic.new(name: "temp", max_choosers: 10)
-      temp.category = "category"
-      temp.topic_identifier = "id"
-      temp.description = "desc"
-      temp2 = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
-      expect(temp2.name).to eq(temp.name)
-      expect(temp2.category).to eq(temp.category)
-      expect(temp2.max_choosers).to eq(temp.max_choosers)
-      expect(temp2.topic_identifier).to eq(temp.topic_identifier)
-      expect(temp2.description).to eq(temp.description)
+  describe "CRUD method tests" do
+    it "creates record via helper method" do
+      first_record = SignUpTopic.new(name: "temp", max_choosers: 10)
+      first_record.category = "category"
+      first_record.topic_identifier = "id"
+      first_record.description = "desc"
+      created_record = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
+      expect(created_record.name).to eq(first_record.name)
+      expect(created_record.category).to eq(first_record.category)
+      expect(created_record.max_choosers).to eq(first_record.max_choosers)
+      expect(created_record.topic_identifier).to eq(first_record.topic_identifier)
+      expect(created_record.description).to eq(first_record.description)
+    end
+
+    it "updates record via helper method" do
+      original_record = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
+      updated_record = SignUpTopic.update_topic("temp", 20, "category2", "desc2")
+      expect(updated_record.max_choosers).to eq(20)
+      expect(updated_record.category).to eq("category2")
+      expect(updated_record.description).to eq("desc2")
     end
   end
 

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe SignUpTopic, type: :model do
       expect(updated_record.category).to eq("category2")
       expect(updated_record.description).to eq("desc2")
     end
+
+    it "deletes record via name" do
+      original_record = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
+      SignUpTopic.delete_topic("temp")
+      deleted_record = SignUpTopic.where(name: "temp")
+      expect(deleted_record.empty?)
+    end
   end
 
 end

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -13,4 +13,19 @@ RSpec.describe SignUpTopic, type: :model do
     expect(SignUpTopic.new(name: "temp", max_choosers: 10)).to be_valid
   end
 
+  describe "test helper methods" do
+    it "create record via helper method" do
+      temp = SignUpTopic.new(name: "temp", max_choosers: 10)
+      temp.category = "category"
+      temp.topic_identifier = "id"
+      temp.description = "desc"
+      temp2 = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
+      expect(temp2.name).to eq(temp.name)
+      expect(temp2.category).to eq(temp.category)
+      expect(temp2.max_choosers).to eq(temp.max_choosers)
+      expect(temp2.topic_identifier).to eq(temp.topic_identifier)
+      expect(temp2.description).to eq(temp.description)
+    end
+  end
+
 end

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe SignUpTopic, type: :model do
       deleted_record = SignUpTopic.where(name: "temp")
       expect(deleted_record.empty?)
     end
+
+    it "checks formatting of records" do
+      record = SignUpTopic.create_topic("temp", 10, "category", "id", "desc")
+      formatted_value = record.format_for_display()
+      expected_value = "id - temp"
+      expect(formatted_value).to eq(expected_value)
+    end
   end
 
 end


### PR DESCRIPTION
This change adds tests for all the helper methods defined in the sign_up_topic model. Tests include:
1. Unit test for create topic method
2. Unit test for update topic method
3. Unit test for delete topic method
4. Unit test for formatter method
5. Unit tests for validations verification
6. Unit tests for positive scenario (i.e., all validations successful)